### PR TITLE
Provide base devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+
+ARG NODE_VERSION=18
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
+
+# VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
+ARG VARIANT=hugo
+# VERSION can be either 'latest' or a specific version number
+ARG VERSION=latest
+
+# Download Hugo
+RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    case ${VERSION} in \
+    latest) \
+    export VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}') ;;\
+    esac && \
+    echo ${VERSION} && \
+    case $(uname -m) in \
+    aarch64) \
+    export ARCH=ARM64 ;; \
+    *) \
+    export ARCH=64bit ;; \
+    esac && \
+    echo ${ARCH} && \
+    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-${ARCH}.tar.gz && \
+    tar xf ${VERSION}.tar.gz && \
+    mv hugo /usr/bin/hugo
+
+# Hugo dev server port
+EXPOSE 1313
+
+# [Optional] Uncomment this section to install additional OS packages you may want.
+#
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN sudo -u node npm install -g <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+    "name": "Hugo (Community)",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            // Update VARIANT to pick hugo variant.
+            // Example variants: hugo, hugo_extended
+            // Rebuild the container if it already exists to update.
+            "VARIANT": "hugo_extended",
+            // Update VERSION to pick a specific hugo version.
+            // Example versions: latest, 0.73.0, 0,71.1
+            // Rebuild the container if it already exists to update.
+            "VERSION": "0.111.3",
+            // Update NODE_VERSION to pick the Node.js version: 18, 16, 14
+            "NODE_VERSION": "18"
+        }
+    },
+
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VSCode.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "html.format.templating": true
+            },
+
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "bungcip.better-toml",
+                "davidanson.vscode-markdownlint"
+            ]
+        }
+    },
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        1313
+    ],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "uname -a",
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "node"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# VSCode Hugo Development Container
+This repository contains configuration files for a [Hugo](https://gohugo.io/) development container for use with VSCode.
+
+## Summary
+
+*Develop static sites with Hugo, includes everything you need to get up and running.*
+
+|          Metadata           |                    Value                     |
+| --------------------------- | -------------------------------------------- |
+| *Categories*                | Community, Frameworks                        |
+| *Definition type*           | Dockerfile                                   |
+| *Works in Codespaces*       | Yes                                          |
+| *Container host OS support* | Linux, macOS, Windows                        |
+| *Container OS*              | Debian                                       |
+| *Languages, platforms*      | Hugo                                         |
+
+This development container includes the Hugo static site generator as well as Node.js (to help with working on themes).
+
+There are 3 configuration options in the `devcontainer.json` file:
+
+- `VARIANT`: the default value is `hugo`. Set this to `hugo_extended` if you want to use SASS/SCSS
+- `VERSION`: version of Hugo to download, e.g. `0.71.1`. The default value is `latest`, which always picks the latest version available.
+- `NODE_VERSION`: version of Node.js to use, for example `14` (the default value)
+
+The `.vscode` folder additionally contains a sample `tasks.json` file that can be used to set up Visual Studio Code [tasks](https://code.visualstudio.com/docs/editor/tasks) for working with Hugo sites.
+
+## Using this definition
+
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
+
+2. Start VS Code and open your project folder or connect to a codespace.
+
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
+
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
+
+## License
+
+Copyright (c) Peter Sellars. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/petersellars/vscode-hugo-devcontainer/blob/main/LICENSE).
+
+### References
+
+* [Microsoft Docs: Create a Dev Container](https://code.visualstudio.com/docs/devcontainers/create-dev-container)
+
+* [Microsoft VSCode Hugo Configuration](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/hugo)


### PR DESCRIPTION
Provide the initial `.devcontainer` configuration files

- devcontainer.json
- Dockerfile

Provided supporting README for the configurations too.

Closes #1 