### PR TITLE
add vscode tasks example configuration

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 README.md
 .npmignore
+.vscode

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Serve Drafts",
+            "type": "shell",
+            "command": "hugo server -D",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "isBackground": true,
+            "problemMatcher": []
+        },
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "hugo",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -48,5 +48,6 @@ Licensed under the MIT License. See [LICENSE](https://github.com/petersellars/vs
 
 * [Microsoft Docs: Create a Dev Container](https://code.visualstudio.com/docs/devcontainers/create-dev-container)
 * [Microsoft Docs: Dev Container Template Reference](https://containers.dev/implementors/templates/)
+* [Microsoft Docs: Integrate with External Tools via Tasks](https://code.visualstudio.com/docs/editor/tasks#vscode)
 
 * [Microsoft VSCode Hugo Configuration](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/hugo)


### PR DESCRIPTION
Added build and serve draft tasks for VSCode use in an example configuration.

Closes #6 